### PR TITLE
addition of typescript dependency to resolve 'tsc' issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   "dependencies": {
     "angular2": "2.0.0-alpha.45",
     "systemjs": "0.19.2"
+  },
+  "devDependencies": {
+    "typescript": "^1.6.2"
   }
 }


### PR DESCRIPTION
Added typescript dependency to resolve an issue ('tsc' is not recognized as an internal or external command, operable program or batch file) when running "npm start" for those that don't have typescript installed globally. Cheers.
